### PR TITLE
disable validations

### DIFF
--- a/recipes/tools.rb
+++ b/recipes/tools.rb
@@ -7,7 +7,8 @@
 # Copyright (c) 2014 Undead Labs, LLC
 #
 
-validate_attributes "instrumental"
+# disabled until the validation cookbook works with chef 12
+#validate_attributes "instrumental"
 
 include_recipe "runit"
 


### PR DESCRIPTION
Validations from this cookbook are failing 100% of the time when used with chef 12 on some of our cookbooks. Disable until we can figure out what's wrong with the validation cookbook.