### PR TITLE
Add instrumental.enabled attribute to control service activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Enhancements
   * Officially support Ubuntu 14.04
+  * add `instrumental.enabled` attribute for controlling whether the service gets enabled and started
+  * the `instrumental.api_key` attribute is no longer required
 
 * Backwards incompatible changes
   * Drop official support for Ubuntu 12.04

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,3 +8,4 @@
 #
 
 default[:instrumental][:api_key] = nil
+default[:instrumental][:enabled] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,8 +13,9 @@ depends "validation", ">= 0.2.0"
 
 grouping "instrumental",
   title: "Instrumental"
-attribute "instrumental/api_key",
+attribute "instrumental/enabled",
   required: "required",
+  type: "boolean",
   recipes: [
     "instrumental::tools"
   ]

--- a/recipes/tools.rb
+++ b/recipes/tools.rb
@@ -25,5 +25,10 @@ chef_gem "instrumental_tools"
 
 runit_service "instrumental_tools" do
   default_logger true
-  action [:enable, :start]
+
+  if node[:instrumental][:enabled]
+    action [:enable, :start]
+  else
+    action :create
+  end
 end


### PR DESCRIPTION
The goal here is to be able to use this cookbook to install the server without
an api key and without starting the service so it can be baked into an AMI.
